### PR TITLE
correct spelling mistake 'tre' to 'true'

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -495,7 +495,7 @@ paths:
                   are able to segment / split the text into space-separated words yourself 
                   before indexing and querying.
 
-                  Set this parameter to tre to do the same
+                  Set this parameter to true to do the same
                 type: boolean
 
               enable_overrides:


### PR DESCRIPTION
Correct spelling mistake of 'tre' to 'true'.