### PR TITLE
correct spelling mistake 'tre' to 'true'

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1638,7 +1638,7 @@ components:
             are able to segment / split the text into space-separated words yourself 
             before indexing and querying.
 
-            Set this parameter to tre to do the same
+            Set this parameter to true to do the same
           type: boolean
 
         enable_overrides:
@@ -1875,7 +1875,7 @@ components:
             are able to segment / split the text into space-separated words yourself 
             before indexing and querying.
 
-            Set this parameter to tre to do the same
+            Set this parameter to true to do the same
           type: boolean
 
         enable_overrides:


### PR DESCRIPTION
Corrects spelling mistakes of 'tre' to 'true'.