### PR TITLE
fix: FacetCount.Stats properties to be float

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2002,11 +2002,14 @@ components:
           type: object
           properties:
             max:
-              type: integer
+              type: number
+              format: float
             min:
-              type: integer
+              type: number
+              format: float
             sum:
-              type: integer
+              type: number
+              format: float
             total_values:
               type: integer
             avg:


### PR DESCRIPTION
## Change Summary
- Collection fields could be `float`, hence the max/min/sum

Closes #27 

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
