### PR TITLE
Added response codes, fixed content types

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1123,6 +1123,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MultiSearchResult"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
 
 components:
   schemas:

--- a/openapi.yml
+++ b/openapi.yml
@@ -80,6 +80,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CollectionResponse"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
         409:
           description: Collection already exists
           content:
@@ -141,6 +147,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CollectionUpdateSchema"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
         404:
           description: The collection was not found
           content:
@@ -394,6 +406,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchOverride"
+        404:
+          description: Search override not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     delete:
       tags:
         - documents
@@ -420,6 +438,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchOverride"
+        404:
+          description: Search override not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
   /collections/{collectionName}/synonyms:
     get:
       tags:
@@ -440,6 +464,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchSynonymsResponse"
+        404:
+          description: Search synonyms was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
   /collections/{collectionName}/synonyms/{synonymId}:
     get:
       tags:
@@ -467,6 +497,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchSynonym"
+        404:
+          description: Search synonym was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     put:
       tags:
         - documents
@@ -500,6 +536,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchSynonym"
+        404:
+          description: Search synonym was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     delete:
       tags:
         - documents
@@ -525,6 +567,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchSynonym"
+        404:
+          description: Search synonym not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+
   /collections/{collectionName}/documents/export:
     get:
       tags:
@@ -573,7 +622,7 @@ paths:
         404:
           description: The collection was not found
           content:
-            application/octet-stream:
+            application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
   /collections/{collectionName}/documents/import:
@@ -632,6 +681,12 @@ paths:
                 example: |
                   {"success": true}
                   {"success": false, "error": "Bad JSON.", "document": "[bad doc"}
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
         404:
           description: The collection was not found
           content:
@@ -785,6 +840,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiKey"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+        409:
+          description: API key generation conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
   /keys/{keyId}:
     get:
       tags:
@@ -810,6 +877,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiKey"
+        404:
+          description: The key was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     delete:
       tags:
         - keys
@@ -830,6 +903,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiKey"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+        404:
+          description: Key not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
   /aliases:
     get:
       tags:
@@ -876,6 +961,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CollectionAlias"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+        404:
+          description: Alias not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     get:
       tags:
         - collections
@@ -896,6 +993,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CollectionAlias"
+        404:
+          description: The alias was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     delete:
       tags:
         - collections
@@ -915,6 +1018,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CollectionAlias"
+        404:
+          description: Alias not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
   /debug:
     get:
       tags:
@@ -1048,7 +1157,7 @@ components:
             The name of an int32 / float field that determines the order in which
             the search results are ranked when a sort_by clause is not provided during
             searching. This field must indicate some kind of popularity.
-          example: num_employees
+          example: company_name # Go with the first field name listed above to produce sane defaults
           default: ""
         token_separators:
           type: array
@@ -1057,6 +1166,10 @@ components:
             splitting the text into individual words in addition to space and new-line characters.
           items:
             type: string # characters only
+            # Could `enum` be used instead, given it's symbols/special *characters*, e.g.:
+            # enum: ["@", "!", ".", "/", ","]
+            minLength: 1
+            maxLength: 1
           default: []
 
         symbols_to_index:
@@ -1065,6 +1178,10 @@ components:
             List of symbols or special characters to be indexed.
           items:
             type: string # characters only
+            # Could `enum` be used instead, given it's symbols/special *characters*, e.g.:
+            # enum: ["@", "!", ".", "/", ","]
+            minLength: 1
+            maxLength: 1
           default: []
     CollectionUpdateSchema:
       required:


### PR DESCRIPTION
Left comments for consideration

## Change Summary

We are testing typesense using GUARDARA and so far we found some documentation-related issues. Thought we could share our improvements/fixes:

 * Documented more of the possible responses for some of the operations.
 * Fixed one response content type that was incorrect.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
