### PR TITLE
Add preset to SearchParameters and MultiSearchParameters

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1941,6 +1941,12 @@ components:
             Set this parameter to true to do the same
           type: boolean
 
+        preset:
+          description: >
+            Search using a bunch of search parameters by setting this parameter to
+            the name of the existing Preset.
+          type: string
+
         enable_overrides:
           description: >
             If you have some overrides defined but want to disable all of them during
@@ -2202,6 +2208,12 @@ components:
 
             Set this parameter to true to do the same
           type: boolean
+
+        preset:
+          description: >
+            Search using a bunch of search parameters by setting this parameter to
+            the name of the existing Preset.
+          type: string
 
         enable_overrides:
           description: >


### PR DESCRIPTION
## Change Summary
As documented in https://github.com/typesense/typesense-java/issues/41, the preset feature is missing from the Java SDK. Updating `typesense-api-spec` is listed as the first step for making changes to  `typesense-java`.

This PR adds the `preset` field to both SearchParameters and MultiSearchParameters in the OpenAPI spec.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
