### PR TITLE
Add type for highlight field

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1462,7 +1462,12 @@ components:
         highlight:
           type: object
           description: Highlighted version of the matching document
-          additionalProperties: true
+          additionalProperties:
+            oneOf:
+              - $ref: "#/components/schemas/SearchHighlightV2"
+              - type: array
+                items:
+                  $ref: "#/components/schemas/SearchHighlightV2"
         document:
           type: object
           description: Can be any key-value pair
@@ -1534,6 +1539,27 @@ components:
           items:
             type: object
             x-go-type: "interface{}"
+    SearchHighlightV2:
+      type: object
+      required:
+        - snippet
+        - matched_tokens
+      properties:
+        snippet:
+          type: string
+          description: The highlighted snippet
+          example: <mark>Stark</mark> Industries
+        value:
+          type: string
+          description: Full field value with highlighting
+          example: <mark>Stark</mark> Industries is a major supplier of space equipment.
+        matched_tokens:
+          type: array
+          description: The matching tokens in the field value
+          items:
+            type: string
+          example:
+            - Stark
     SearchOverrideSchema:
       type: object
       required:


### PR DESCRIPTION
## Change Summary
This PR introduces a new `SearchHighlightV2` type which is used for the `SearchResultHit#highlight` field.

I've opened this as a draft as this version of the spec doesn't quite play nicely with the generator used by `typesense-go` (it creates some weirdly named structs). The generated Go version can be a bit nicer by making these changes:

```diff
--- openapi.yml
+++ openapi.yml
@@ -1465,9 +1465,7 @@
           additionalProperties:
             oneOf:
               - $ref: "#/components/schemas/SearchHighlightV2"
-              - type: array
-                items:
-                  $ref: "#/components/schemas/SearchHighlightV2"
+              - $ref: "#/components/schemas/SearchHighlightV2Array"
         document:
           type: object
           description: Can be any key-value pair
@@ -1560,6 +1558,10 @@
             type: string
           example:
             - Stark
+    SearchHighlightV2Array:
+      type: array
+      items:
+        $ref: "#/components/schemas/SearchHighlightV2"
     SearchOverrideSchema:
       type: object
       required:
```

Annoyingly, the Go version still doesn't offer a way to detect if the `oneOf` is an array or not, instead throwing an error if you call the wrong `AsSearchHighlightV2*` function.

But introducing an additional schema seems less than ideal. I'm open to any suggestions on how to improve this further.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
