### PR TITLE
Add PUT endpoint for upserts in Analytics api.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1239,6 +1239,40 @@ paths:
               schema:
                 $ref: "#/components/schemas/AnalyticsRulesRetrieveSchema"
   /analytics/rules/{ruleName}:
+    put:
+      tags:
+        - analytics
+      summary: Upserts an analytics rule
+      description:
+        Upserts an analytics rule with the given name.
+      operationId: upsertAnalyticsRule
+      parameters:
+        - in: path
+          name: ruleName
+          description: The name of the analytics rule to upsert
+          schema:
+            type: string
+          required: true
+      requestBody:
+        description: The Analytics rule to be upserted
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnalyticsRuleSchema"
+        required: true
+      responses:
+        201:
+          description: Analytics rule successfully upserted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnalyticsRuleSchema"
+        400:
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     get:
       tags:
         - analytics


### PR DESCRIPTION
## Change Summary
Added the PUT operation to Analytics Rules to the OpenApi spec. This PUT operations allows the user to upsert an analytics rule.
This is an update for the changes added in https://github.com/typesense/typesense-api-spec/pull/44

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
