### PR TITLE
Remove single search parameter from multi search spec

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1177,12 +1177,6 @@ paths:
       description:
         This is especially useful to avoid round-trip network latencies incurred otherwise if each of these requests are sent in separate HTTP requests.
         You can also use this feature to do a federated search across multiple collections in a single HTTP request.
-      parameters:
-        - name: multiSearchParameters
-          required: true
-          in: query
-          schema:
-            $ref: "#/components/schemas/MultiSearchParameters"
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Change Summary
Fixed https://github.com/typesense/typesense-api-spec/issues/51
Seems that this was copied from the single search by mistake

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
