### PR TITLE
Make the search parameters `q` and `query_by` optional

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2404,10 +2404,6 @@ components:
           $ref: "#/components/schemas/SearchResultConversation"
     SearchParameters:
       type: object
-      required:
-        - q
-        - query_by
-
       properties:
         q:
           description: The query text to search for in the collection.


### PR DESCRIPTION
`q` and `query_by` have to be optional in order to use preset

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
