### PR TITLE
fix: use correct response type for key deletion

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1105,7 +1105,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApiKey"
+                $ref: "#/components/schemas/ApiKeyDeleteResponse"
         400:
           description: Bad request, see error message for details
           content:
@@ -2363,6 +2363,15 @@ components:
             value_prefix:
               type: string
               readOnly: true
+    ApiKeyDeleteResponse:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The id of the API key that was deleted
     ApiKeysResponse:
       type: object
       required:


### PR DESCRIPTION
## Change Summary
The current API spec defines the return schema of a successful DELETE request on the `/keys/{keyId}` endpoint as `ApiKey`, matching the ones from either GET, POST, or PUT requests. Actually calling the API presents a JSON object with only the `id` field being defined:

```shell
❯ curl -k "http://localhost:8108/keys/12" \
     -X DELETE \
     -H "Content-Type: application/json" \
     -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"
{"id": 12}
```
## Changes
* fix response schema for DELETE /keys/{keyId} endpoint
* add missing ApiKeyDeleteResponse schema definition
* ensure id field description matches actual response

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
