### PR TITLE
docs: add synonyms tag to API spec

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -56,6 +56,11 @@ tags:
     externalDocs:
       description: Find out more
       url: https://typesense.org/docs/27.0/api/conversational-search-rag.html
+  - name: synonyms
+    description: Manage synonyms
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/27.0/api/synonyms.html
 paths:
   /collections:
     get:
@@ -534,7 +539,7 @@ paths:
   /collections/{collectionName}/synonyms:
     get:
       tags:
-        - documents
+        - synonyms
       summary: List all collection synonyms
       operationId: getSearchSynonyms
       parameters:
@@ -560,7 +565,7 @@ paths:
   /collections/{collectionName}/synonyms/{synonymId}:
     get:
       tags:
-        - documents
+        - synonyms
       summary: Retrieve a single search synonym
       description: Retrieve the details of a search synonym, given its id.
       operationId: getSearchSynonym
@@ -592,7 +597,7 @@ paths:
                 $ref: "#/components/schemas/ApiResponse"
     put:
       tags:
-        - documents
+        - synonyms
       summary: Create or update a synonym
       description: Create or update a synonym  to define search terms that should be considered equivalent.
       operationId: upsertSearchSynonym
@@ -631,7 +636,7 @@ paths:
                 $ref: "#/components/schemas/ApiResponse"
     delete:
       tags:
-        - documents
+        - synonyms
       summary: Delete a synonym associated with a collection
       operationId: deleteSearchSynonym
       parameters:


### PR DESCRIPTION
## Change Summary
The synonym spec was nested under the Document tag, this introduces a new tag for synonyms specifically.

## Changes
* add synonyms tag definition with documentation links
* add synonyms tag alongside documents for synonym endpoints
* clarify API endpoint categorization in swagger UI

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
