### PR TITLE
fix: use correct response for override deletion

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -524,7 +524,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SearchOverride"
+                $ref: "#/components/schemas/SearchOverrideDeleteResponse"
         404:
           description: Search override not found
           content:
@@ -2213,6 +2213,14 @@ components:
             id:
               type: string
               readOnly: true
+    SearchOverrideDeleteResponse:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The id of the override that was deleted
     SearchOverrideRule:
       type: object
       properties:


### PR DESCRIPTION
## Change Summary
The current API spec defines the return schema of a successful DELETE request on the `/collections/{collectionName}/overrides/{overrideId}` endpoint as `SearchOverride`, matching the ones from either GET, POST, or PUT requests. Actually calling the API presents a JSON object with only the `id` field being defined:

```shell
❯ curl -k "http://localhost:8108/collections/books/overrides/customize-apple" \
     -X DELETE \
     -H "Content-Type: application/json" \
     -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"
{"id":"customize-apple"}
```
## Changes

* fix response schema for DELETE /keys/{keyId} endpoint
* add missing ApiKeyDeleteResponse schema definition
* ensure id field description matches actual response

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
