### PR TITLE
fix: fix synonym delete response schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -653,7 +653,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SearchSynonym"
+                $ref: "#/components/schemas/SearchSynonymDeleteResponse"
         404:
           description: Search synonym not found
           content:
@@ -2298,6 +2298,14 @@ components:
             id:
               type: string
               readOnly: true
+    SearchSynonymDeleteResponse:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The id of the synonym that was deleted
     SearchSynonymsResponse:
       type: object
       required:


### PR DESCRIPTION
## Change Summary
The current API spec defines the return schema of a successful DELETE request on the `/collection/{collectionName}/synonyms/{synonymId}` endpoint as `SearchSynonym`, matching the ones from either GET, POST, or PUT requests. Actually calling the API presents a JSON object with only the `id` field being defined:

```shell
❯ curl "http://localhost:8108/collections/products/synonyms/coat-synonyms" -X DELETE \
-H "Content-Type: application/json" \
-H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"

{"id":"coat-synonyms"}
```
## Changes
* fix response schema for DELETE `/collection/{collectionName}/synonyms/{synonymId}` endpoint
* add missing SearchSynonymDeleteReponse schema definition

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

