### PR TITLE
Changed some tags for better grouping

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -416,7 +416,6 @@ paths:
   /collections/{collectionName}/overrides:
     get:
       tags:
-        - documents
         - curation
       summary: List all collection overrides
       operationId: getSearchOverrides
@@ -437,7 +436,6 @@ paths:
   /collections/{collectionName}/overrides/{overrideId}:
     get:
       tags:
-        - documents
         - curation
       summary: Retrieve a single search override
       description: Retrieve the details of a search override, given its id.
@@ -464,7 +462,6 @@ paths:
                 $ref: "#/components/schemas/SearchOverride"
     put:
       tags:
-        - documents
         - curation
       summary: Create or update an override to promote certain documents over others
       description:
@@ -506,7 +503,6 @@ paths:
                 $ref: "#/components/schemas/ApiResponse"
     delete:
       tags:
-        - documents
         - curation
       summary: Delete an override associated with a collection
       operationId: deleteSearchOverride

--- a/openapi.yml
+++ b/openapi.yml
@@ -438,7 +438,7 @@ paths:
     get:
       tags:
         - documents
-        - override
+        - curation
       summary: Retrieve a single search override
       description: Retrieve the details of a search override, given its id.
       operationId: getSearchOverride


### PR DESCRIPTION
## Change Summary
Changed override tag to curation in one of the endpoints to group it with the other curation/override endpoints.
 
Also removed documents tags from all overrides to not list them with documents endpoints, like it is with all other endpoints in the document.

I'd probably also group the /debug, /health and cluster operations, or at least put them under each other.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
