### PR TITLE
Fixes Geo Distance Meters incorrect type

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2108,7 +2108,8 @@ components:
           type: object
           description: Can be any key-value pair
           additionalProperties:
-            type: float
+             type: number
+             format: float
         vector_distance:
           type: number
           format: float

--- a/openapi.yml
+++ b/openapi.yml
@@ -2108,7 +2108,7 @@ components:
           type: object
           description: Can be any key-value pair
           additionalProperties:
-            type: integer
+            type: float
         vector_distance:
           type: number
           format: float


### PR DESCRIPTION
## Change Summary
Changed type of `SearchResultHit.geo_distance_meters`, still a key-value pair, but the type of the value has been changed from `integer` to `number($float)`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

Full details of issue in https://github.com/typesense/typesense-go/issues/187
