### PR TITLE
Make `MultiSearchCollectionParameters.collection` optional

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -3214,8 +3214,6 @@ components:
       allOf:
         - $ref: "#/components/schemas/MultiSearchParameters"
         - type: object
-          required:
-            - collection
           properties:
             collection:
               type: string


### PR DESCRIPTION

## Change Summary
<!--- Described your changes here -->
This will allow using single search preset (`GET .../search` end-point) inside multi-search searches

![image](https://github.com/user-attachments/assets/4e9954b4-86d6-4e1d-88d5-0157948aafca)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
