### PR TITLE
v28.0

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -61,6 +61,11 @@ tags:
     externalDocs:
       description: Find out more
       url: https://typesense.org/docs/28.0/api/synonyms.html
+  - name: stemming
+    description: Manage stemming dictionaries
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/28.0/api/stemming.html
 paths:
   /collections:
     get:
@@ -1761,6 +1766,97 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+  /stemming/dictionaries:
+    get:
+      tags:
+        - stemming
+      summary: List all stemming dictionaries
+      description: Retrieve a list of all available stemming dictionaries.
+      operationId: listStemmingDictionaries
+      responses:
+        '200':
+          description: List of all dictionaries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dictionaries:
+                    type: array
+                    items:
+                      type: string
+                    example: ["irregular-plurals", "company-terms"]
+
+  /stemming/dictionaries/{dictionaryId}:
+    get:
+      tags:
+        - stemming
+      summary: Retrieve a stemming dictionary
+      description: Fetch details of a specific stemming dictionary.
+      operationId: getStemmingDictionary
+      parameters:
+        - name: dictionaryId
+          in: path
+          description: The ID of the dictionary to retrieve
+          required: true
+          schema:
+            type: string
+          example: irregular-plurals
+      responses:
+        '200':
+          description: Stemming dictionary details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StemmingDictionary"
+        '404':
+          description: Dictionary not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+
+  /stemming/dictionaries/import:
+    post:
+      tags:
+        - stemming
+      summary: Import a stemming dictionary
+      description: Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+      operationId: importStemmingDictionary
+      parameters:
+        - name: id
+          in: query
+          description: The ID to assign to the dictionary
+          required: true
+          schema:
+            type: string
+          example: irregular-plurals
+      requestBody:
+        description: The JSONL file containing word mappings
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              example: |
+                {"word": "people", "root": "person"}
+                {"word": "children", "root": "child"}
+      responses:
+        '200':
+          description: Dictionary successfully imported
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                example: >
+                  {"word": "people", "root": "person"}
+                  {"word": "children", "root": "child"}
+        '400':
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
 components:
   schemas:
     CollectionSchema:
@@ -1925,6 +2021,10 @@ components:
           type: boolean
           description: >
             Values are stemmed before indexing in-memory. Default: false.
+        stem_dictionary:
+          type: string
+          description: Name of the stemming dictionary to use for this field
+          example: irregular-plurals
         token_separators:
           type: array
           description: >
@@ -3654,6 +3754,33 @@ components:
             id:
               type: string
               description: An explicit id for the model, otherwise the API will return a response with an auto-generated conversation model id.
+    StemmingDictionary:
+      type: object
+      required:
+        - id
+        - words
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the dictionary
+          example: irregular-plurals
+        words:
+          type: array
+          description: List of word mappings in the dictionary
+          items:
+            type: object
+            required:
+              - word
+              - root
+            properties:
+              word:
+                type: string
+                description: The word form to be stemmed
+                example: people
+              root:
+                type: string
+                description: The root form of the word
+                example: person
   securitySchemes:
     api_key_header:
       type: apiKey

--- a/openapi.yml
+++ b/openapi.yml
@@ -3271,6 +3271,13 @@ components:
             x-typesense-api-key:
               type: string
               description: A separate search API key for each search within a multi_search request
+            rerank_hybrid_matches:
+              type: boolean
+              description: >
+                When true, computes both text match and vector distance scores for all matches in hybrid search.
+                Documents found only through keyword search will get a vector distance score, and
+                documents found only through vector search will get a text match score.
+              default: false
     FacetCounts:
       type: object
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2527,6 +2527,12 @@ components:
           type: string
           example: "num_employees:>100 && country: [USA, UK]"
 
+        max_filter_by_candidates:
+          description:
+            Controls the number of similar words that Typesense considers during fuzzy search
+            on filter_by values. Useful for controlling prefix matches like company_name:Acm*.
+          type: integer
+
         sort_by:
           description:
             A list of numerical fields and their corresponding sort orders

--- a/openapi.yml
+++ b/openapi.yml
@@ -3224,6 +3224,9 @@ components:
       required:
         - searches
       properties:
+        union:
+          type: boolean
+          description: When true, merges the search results from each search query into a single ordered set of hits.
         searches:
           type: array
           items:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1263,6 +1263,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthStatus"
+  /operations/schema_changes:
+    get:
+      tags:
+        - operations
+      summary: Get the status of in-progress schema change operations
+      description: Returns the status of any ongoing schema change operations. If no schema changes are in progress, returns an empty response.
+      operationId: getSchemaChanges
+      responses:
+        '200':
+          description: List of schema changes in progress
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SchemaChangeStatus"
   /operations/snapshot:
     post:
       tags:
@@ -2353,6 +2369,18 @@ components:
       properties:
         ok:
           type: boolean
+    SchemaChangeStatus:
+      type: object
+      properties:
+        collection:
+          type: string
+          description: Name of the collection being modified
+        validated_docs:
+          type: integer
+          description: Number of documents that have been validated
+        altered_docs:
+          type: integer
+          description: Number of documents that have been altered
     SuccessStatus:
       type: object
       required:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Typesense API
   description: "An open source search engine for building delightful search experiences."
-  version: '27.0'
+  version: '28.0'
 externalDocs:
   description: Find out more about Typsesense
   url: https://typesense.org

--- a/openapi.yml
+++ b/openapi.yml
@@ -1922,6 +1922,29 @@ components:
           type: boolean
           description: >
             Values are stemmed before indexing in-memory. Default: false.
+        token_separators:
+          type: array
+          description: >
+            List of symbols or special characters to be used for
+            splitting the text into individual words in addition to space and new-line characters.
+          items:
+            type: string # characters only
+            # Could `enum` be used instead, given it's symbols/special *characters*, e.g.:
+            # enum: ["@", "!", ".", "/", ","]
+            minLength: 1
+            maxLength: 1
+          default: []
+        symbols_to_index:
+          type: array
+          description: >
+            List of symbols or special characters to be indexed.
+          items:
+            type: string # characters only
+            # Could `enum` be used instead, given it's symbols/special *characters*, e.g.:
+            # enum: ["@", "!", ".", "/", ","]
+            minLength: 1
+            maxLength: 1
+          default: []
         embed:
           type: object
           required:

--- a/openapi.yml
+++ b/openapi.yml
@@ -28,7 +28,7 @@ tags:
     description: Typesense can aggregate search queries for both analytics purposes and for query suggestions.
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/analytics-query-suggestions.html
+      url: https://typesense.org/docs/28.0/api/analytics-query-suggestions.html
   - name: keys
     description: Manage API Keys with fine-grain access control
     externalDocs:
@@ -40,27 +40,27 @@ tags:
     description: Manage Typesense cluster
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/cluster-operations.html
+      url: https://typesense.org/docs/28.0/api/cluster-operations.html
   - name: stopwords
     description: Manage stopwords sets
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/stopwords.html
+      url: https://typesense.org/docs/28.0/api/stopwords.html
   - name: presets
     description: Store and reference search parameters
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/search.html#presets
+      url: https://typesense.org/docs/28.0/api/search.html#presets
   - name: conversations
     description: Conversational Search (RAG)
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/27.0/api/conversational-search-rag.html
+      url: https://typesense.org/docs/28.0/api/conversational-search-rag.html
   - name: synonyms
     description: Manage synonyms
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/27.0/api/synonyms.html
+      url: https://typesense.org/docs/28.0/api/synonyms.html
 paths:
   /collections:
     get:

--- a/openapi.yml
+++ b/openapi.yml
@@ -357,6 +357,9 @@ paths:
                 type: integer
               ignore_not_found:
                 type: boolean
+              truncate:
+                description: When true, removes all documents from the collection while preserving the collection and its schema.
+                type: boolean
       responses:
         '200':
           description: Documents successfully deleted


### PR DESCRIPTION
## Change Summary
### What is this?
This PR updates the OpenAPI schema documentation to reflect the features and changes in Typesense v28.0. This documentation update ensures that API consumers have accurate information about the available endpoints, parameters, and schemas in the latest version.

### Changes

#### Documentation Updates:

1. **New API Endpoints Documentation**:
   - Added `/stemming/dictionaries` endpoints documentation for the new stemming dictionary feature
   - Added `/operations/schema_changes` endpoint documentation for monitoring schema changes
   - Added new `StemmingDictionary` schema definitions

2. **Updated Search Parameters Documentation**:
   - Added `union` parameter documentation in multi-search requests
   - Added `rerank_hybrid_matches` parameter documentation for hybrid search
   - Added `max_filter_by_candidates` parameter documentation in search parameters
   - Added `truncate` parameter documentation for document deletion

3. **Enhanced Field Schema Documentation**:
   - Added `stem_dictionary` property documentation
   - Added `symbols_to_index` and `token_separators` properties documentation

4. **Version and URL Updates**:
   - Updated version from 27.0 to 28.0
   - Updated all documentation URLs to reference v28.0
   - Added new documentation links for stemming features


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
