### PR TITLE
golang: override `num_tokens_dropped` type with unint64

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2240,6 +2240,8 @@ components:
               type: integer
             num_tokens_dropped:
               type: integer
+              format: int64
+              x-go-type: uint64
             score:
               type: string
             tokens_matched:


### PR DESCRIPTION
fix: https://github.com/typesense/typesense-go/issues/194

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
