### PR TITLE
feat: CI pipeline and OpenAPI specification cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint OpenAPI Specification
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+      
+      - name: Lint OpenAPI specification
+        run: redocly lint openapi.yml
+      
+      - name: Bundle OpenAPI specification
+        run: redocly bundle openapi.yml --output bundled-openapi.yml
+      
+      - name: Upload bundled specification
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundled-openapi
+          path: bundled-openapi.yml

--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -1,0 +1,5 @@
+extends:
+  - recommended
+
+rules:
+  operation-4xx-response: off 

--- a/openapi.yml
+++ b/openapi.yml
@@ -936,6 +936,7 @@ paths:
       tags:
         - conversations
     post:
+      summary: Create a conversation model
       description: Create a Conversation Model
       operationId: createConversationModel
       requestBody:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3,6 +3,19 @@ info:
   title: Typesense API
   description: "An open source search engine for building delightful search experiences."
   version: '28.0'
+servers:
+  - url: "{protocol}://{hostname}:{port}"
+    description: Typesense Server
+    variables:
+      protocol:
+        default: http
+        description: The protocol of your Typesense server
+      hostname:
+        default: localhost
+        description: The hostname of your Typesense server
+      port:
+        default: "8108"
+        description: The port of your Typesense server
 externalDocs:
   description: Find out more about Typsesense
   url: https://typesense.org

--- a/openapi.yml
+++ b/openapi.yml
@@ -3820,12 +3820,6 @@ components:
       properties:
         name:
           type: string
-    # client libraries already have .create, .upsert,... methods so we omit the `action` param
-    DocumentIndexParameters:
-      type: object
-      properties:
-        dirty_values:
-          $ref: "#/components/schemas/DirtyValues"
     DirtyValues:
       type: string
       enum: [coerce_or_reject, coerce_or_drop, drop, reject]

--- a/openapi.yml
+++ b/openapi.yml
@@ -2718,14 +2718,6 @@ components:
           x-go-type: "[]*ApiKey"
           items:
             $ref: "#/components/schemas/ApiKey"
-    ScopedKeyParameters:
-      type: object
-      properties:
-        filter_by:
-          type: string
-        expires_at:
-          type: integer
-          format: int64
     SnapshotParameters:
       type: object
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3,6 +3,9 @@ info:
   title: Typesense API
   description: "An open source search engine for building delightful search experiences."
   version: '28.0'
+  license:
+    name: GPL-3.0
+    url: https://opensource.org/licenses/GPL-3.0
 servers:
   - url: "{protocol}://{hostname}:{port}"
     description: Typesense Server

--- a/openapi.yml
+++ b/openapi.yml
@@ -72,6 +72,7 @@ tags:
       description: Find out more
       url: https://typesense.org/docs/29.0/api/natural-language-search.html
 
+paths:
   /collections:
     get:
       tags:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2718,11 +2718,6 @@ components:
           x-go-type: "[]*ApiKey"
           items:
             $ref: "#/components/schemas/ApiKey"
-    SnapshotParameters:
-      type: object
-      properties:
-        snapshot_path:
-          type: string
     MultiSearchResult:
       type: object
       required:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2731,11 +2731,6 @@ components:
       properties:
         snapshot_path:
           type: string
-    ErrorResponse:
-      type: object
-      properties:
-        message:
-          type: string
     MultiSearchResult:
       type: object
       required:


### PR DESCRIPTION
## TLDR 
Add CI pipeline for OpenAPI linting/bundling and clean up unused schema components.

## Change summary

### Added Features:
1. **New CI Pipeline in `.github/workflows/lint.yml`**:
   - `lint job`: Validates OpenAPI specification using Redocly CLI on push/PR events
   - `bundle step`: Creates bundled OpenAPI specification as build artifact
   - `upload artifact`: Stores bundled specification for download

2. **New Configuration in `.redocly.yaml`**:
   - `extends recommended`: Applies Redocly's recommended linting rules
   - `operation-4xx-response rule`: Disabled to allow endpoints without 4xx responses

### Documentation Updates:
1. **In `openapi.yml`**:
   - **Removed Unused Schemas**: Cleaned up `DocumentIndexParameters`, `ScopedKeyParameters`, `SnapshotParameters`, and `ErrorResponse` components
   - **Enhanced Metadata**: Added proper server configuration and license information for better API documentation
   - **Server Configuration**: Added configurable server URL with protocol, hostname, and port variables
   - **License Information**: Added GPL-3.0 license with URL reference
   - **POST Summary**: Added missing summary for conversation model creation endpoint

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
