### PR TITLE
Revert: re-adding `paths:`

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -72,6 +72,7 @@ tags:
       description: Find out more
       url: https://typesense.org/docs/29.0/api/natural-language-search.html
 
+paths:
   /collections:
     get:
       tags:


### PR DESCRIPTION
Seem like the `paths:` was unintentionally deleted in https://github.com/typesense/typesense-api-spec/commit/ee1f60d6b856b9f973392a05017ecb3995c15cd3

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
