### PR TITLE
feat: add getCollectionsParameters and missing metadata fields to CollectionSchema and CollectionUpdateSchema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2099,6 +2099,10 @@ components:
           default: []
         voice_query_model:
           $ref: "#/components/schemas/VoiceQueryModelCollectionConfig"
+        metadata:
+          type: object
+          description: >
+            Optional details about the collection, e.g., when it was created, who created it etc.
     CollectionUpdateSchema:
       required:
         - fields
@@ -2119,6 +2123,10 @@ components:
               facet: true
           items:
             $ref: "#/components/schemas/Field"
+        metadata:
+          type: object
+          description: >
+            Optional details about the collection, e.g., when it was created, who created it etc.
     CollectionResponse:
       allOf:
         - $ref: "#/components/schemas/CollectionSchema"


### PR DESCRIPTION
## Change Summary

1. Adds `exclude_fields` to `List all collections` endpoint (https://typesense.org/docs/29.0/api/collections.html#list-all-collections)
2. Adds `metadata` fields to `create/update collection` endpoint (https://typesense.org/docs/29.0/api/collections.html#adding-metadata-to-schema)

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
