### PR TITLE
Add support for disabling auto aggregation on analytics rules

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -3690,6 +3690,8 @@ components:
           type: array
           items:
             type: string
+        enable_auto_aggregation:
+          type: boolean
         events:
           type: array
           items:


### PR DESCRIPTION
## Change Summary
This PR adds missing support for disabling/enabling auto aggregation when specifying the source of an analytics rule. See [here](https://typesense.org/docs/29.0/api/analytics-query-suggestions.html#send-events-via-api) for details

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
