### PR TITLE
fix: add potential metadata prop to search response object

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2479,6 +2479,10 @@ components:
           description: Returned only for union query response.
           items:
             $ref: "#/components/schemas/SearchRequestParams"
+        metadata:
+          type: object
+          description: Custom JSON object that can be returned in the search response
+          additionalProperties: true
     SearchRequestParams:
       type: object
       required:


### PR DESCRIPTION
## Change Summary
Curation rules can return an arbitrary JSON object when fired. This adds it to the API spec in order for the clietn libraries to take advantage of it.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
