### PR TITLE
fix: only require at least 1 field to be present in a collection update

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2479,9 +2479,8 @@ components:
           description: >
             Optional details about the collection, e.g., when it was created, who created it etc.
     CollectionUpdateSchema:
-      required:
-        - fields
       type: object
+      minProperties: 1
       properties:
         fields:
           type: array


### PR DESCRIPTION
## Change Summary
The collection update endpoint only requires that at least one property is present - "fields" is not strictly required (e.g. when doing metadata updates).

https://github.com/typesense/typesense/blob/1c5804194175210b3fbdd4972ba3cff2bbdf85cf/src/core_api.cpp#L301-L367

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
